### PR TITLE
Fix torrent.nameindex in spider.js

### DIFF
--- a/src/background/spider.js
+++ b/src/background/spider.js
@@ -645,7 +645,7 @@ module.exports = function (send, recive, dataDirectory, version, env)
 					addFilesToDatabase()
 				}
 
-				torrent.nameIndex = buildTorrentIndex(torrent)
+				torrent.nameindex = buildTorrentIndex(torrent)
 
 				sphinxSingle.insertValues('torrents', torrent, function(err, result) {
 					if(result) {


### PR DESCRIPTION
Fix torrent.nameindex in spider.js. This fixes the ER_FIELD_SPECIFIED_TWICE error when adding a torrent to the database.
Исправление torrent.nameindex в spider.js. Это исправляет ошибку ER_FIELD_SPECIFIED_TWICE при добавления торрента в базу данных.